### PR TITLE
Add zeroize for secrets in WebhookSender and NotificationChannel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ tempfile = "3.10"
 directories = "5"
 getrandom = "0.2"
 secrecy = { version = "0.10", features = ["serde"] }
-zeroize = { version = "1.8", features = ["derive", "serde"] }
 
 [profile.release]
 lto = true

--- a/warden-core/Cargo.toml
+++ b/warden-core/Cargo.toml
@@ -37,7 +37,6 @@ directories = { workspace = true }
 base64 = { workspace = true }
 getrandom = { workspace = true }
 secrecy = { workspace = true }
-zeroize = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/warden-core/src/group.rs
+++ b/warden-core/src/group.rs
@@ -8,8 +8,8 @@ use std::sync::RwLock;
 use uuid::Uuid;
 
 use crate::quorum::GroupId;
+use crate::secrets::SecretValue;
 use crate::Result;
-use zeroize::Zeroizing;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApproverGroup {
@@ -133,11 +133,11 @@ pub enum NotificationChannel {
     },
     Webhook {
         url: String,
-        secret: Zeroizing<String>,
+        secret: SecretValue,
     },
     Slack {
         channel_id: String,
-        token: Zeroizing<String>,
+        token: SecretValue,
     },
     Nostr {
         pubkey: String,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Webhook URL credentials and Slack token secrets in notification channels now use secure value wrapper types across all notification system components.
  * WebhookSender configuration methods and secret processing logic updated to support and handle the new secure value type consistently.
  * Notification channel type definitions and comparison behavior refined to ensure type consistency throughout the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->