### PR TITLE
Use AWS SDK for Secrets Manager provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,8 @@ tempfile = "3.10"
 directories = "5"
 getrandom = "0.2"
 secrecy = { version = "0.10", features = ["serde"] }
+aws-config = "1"
+aws-sdk-secretsmanager = "1"
 
 [profile.release]
 lto = true

--- a/warden-core/Cargo.toml
+++ b/warden-core/Cargo.toml
@@ -37,6 +37,8 @@ directories = { workspace = true }
 base64 = { workspace = true }
 getrandom = { workspace = true }
 secrecy = { workspace = true }
+aws-config = { workspace = true }
+aws-sdk-secretsmanager = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * AWS Secrets Manager integration now uses the official AWS SDK v2 instead of manual HTTP requests for improved reliability and error handling.
  * The primary constructor is now asynchronous.
  * Removed `timeout_seconds` configuration option.
  * Added new constructor for direct AWS SDK client injection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->