### PR TITLE
Enforce explicit HS256 JWT algorithm and 32-byte webhook secret minimum

### DIFF
--- a/warden-api/src/auth.rs
+++ b/warden-api/src/auth.rs
@@ -9,7 +9,7 @@ use governor::{
     state::{InMemoryState, NotKeyed},
     Quota, RateLimiter,
 };
-use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
+use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
 use std::{
     num::NonZeroU32,
@@ -73,9 +73,8 @@ pub struct JwtConfig {
 
 impl JwtConfig {
     pub fn new(secret: &[u8]) -> Self {
-        let mut validation = Validation::default();
+        let mut validation = Validation::new(Algorithm::HS256);
         validation.validate_exp = true;
-        // Allow 30 seconds of clock skew tolerance
         validation.leeway = 30;
         Self {
             encoding_key: EncodingKey::from_secret(secret),
@@ -85,7 +84,7 @@ impl JwtConfig {
     }
 
     pub fn encode(&self, claims: &Claims) -> Result<String, jsonwebtoken::errors::Error> {
-        encode(&Header::default(), claims, &self.encoding_key)
+        encode(&Header::new(Algorithm::HS256), claims, &self.encoding_key)
     }
 
     pub fn decode(&self, token: &str) -> Result<Claims, jsonwebtoken::errors::Error> {

--- a/warden-core/src/notification/senders/webhook.rs
+++ b/warden-core/src/notification/senders/webhook.rs
@@ -86,6 +86,12 @@ impl NotificationSender for WebhookSender {
         let secret = secret
             .ok_or_else(|| NotificationError::Permanent("webhook secret not configured".into()))?;
 
+        if secret.expose().len() < 32 {
+            return Err(NotificationError::Permanent(
+                "webhook secret must be at least 32 bytes".into(),
+            ));
+        }
+
         let timestamp = Utc::now().timestamp();
         let event_type = notification_type_name(notification);
         let payload = serde_json::to_string(notification)


### PR DESCRIPTION
- Explicit HS256 algorithm validation for JWT encoding/decoding
- Minimum 32-byte secret length for webhook HMAC-SHA256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Webhook secrets must now meet a minimum length requirement of 32 bytes
  * Enhanced JWT token validation with explicit algorithm enforcement

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->