### PR TITLE
Replace lock poisoning with parking_lot and fix velocity TOCTOU race

### DIFF
--- a/warden-core/src/notification/store.rs
+++ b/warden-core/src/notification/store.rs
@@ -1,8 +1,8 @@
 //! Notification storage.
 
 use async_trait::async_trait;
+use parking_lot::RwLock;
 use std::collections::HashMap;
-use std::sync::RwLock;
 use uuid::Uuid;
 
 use super::types::{NotificationRecord, NotificationStatus};
@@ -38,7 +38,7 @@ impl Default for InMemoryNotificationStore {
 #[async_trait]
 impl NotificationStore for InMemoryNotificationStore {
     async fn save_record(&self, record: NotificationRecord) -> Result<NotificationRecord> {
-        let mut records = self.records.write().expect("lock poisoned");
+        let mut records = self.records.write();
         records.insert(record.id, record.clone());
         Ok(record)
     }
@@ -47,7 +47,7 @@ impl NotificationStore for InMemoryNotificationStore {
         &self,
         workflow_id: &Uuid,
     ) -> Result<Vec<NotificationRecord>> {
-        let records = self.records.read().expect("lock poisoned");
+        let records = self.records.read();
         Ok(records
             .values()
             .filter(|r| &r.workflow_id == workflow_id)
@@ -56,13 +56,13 @@ impl NotificationStore for InMemoryNotificationStore {
     }
 
     async fn update_record(&self, record: NotificationRecord) -> Result<NotificationRecord> {
-        let mut records = self.records.write().expect("lock poisoned");
+        let mut records = self.records.write();
         records.insert(record.id, record.clone());
         Ok(record)
     }
 
     async fn list_pending(&self) -> Result<Vec<NotificationRecord>> {
-        let records = self.records.read().expect("lock poisoned");
+        let records = self.records.read();
         Ok(records
             .values()
             .filter(|r| r.status == NotificationStatus::Pending)

--- a/warden-core/src/store/redb_store.rs
+++ b/warden-core/src/store/redb_store.rs
@@ -5,10 +5,11 @@ use chacha20poly1305::{
     aead::{Aead, KeyInit},
     ChaCha20Poly1305, Nonce,
 };
+use parking_lot::RwLock;
 use redb::{Database, ReadableTable, TableDefinition};
 use serde::{de::DeserializeOwned, Serialize};
 use std::path::Path;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use uuid::Uuid;
 use zeroize::Zeroizing;
 
@@ -352,7 +353,7 @@ impl CipherOps for RedbPolicyStore {
 
 impl RedbPolicyStore {
     fn find_matching_binding(&self, wallet_id: &str) -> Option<Uuid> {
-        let cache = self.pattern_cache.read().expect("lock poisoned");
+        let cache = self.pattern_cache.read();
         for (pattern, policy_id) in cache.iter() {
             if matches_pattern(pattern, wallet_id) {
                 return Some(*policy_id);
@@ -372,7 +373,7 @@ impl RedbPolicyStore {
             patterns.push((pattern.value().to_string(), uuid));
         }
 
-        let mut cache = self.pattern_cache.write().expect("lock poisoned");
+        let mut cache = self.pattern_cache.write();
         *cache = patterns;
         Ok(())
     }


### PR DESCRIPTION
- Replace std::sync::RwLock with parking_lot::RwLock across 6 files
- Add atomic_check_and_update to VelocityStore trait
- Add saturating_add for overflow protection in velocity calculations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced internal synchronization across core services with a streamlined locking approach for more reliable concurrency.
  * Overhauled velocity logic to add atomic batch check-and-update, a consolidated window iteration, and constructors/defaults for in-memory stores to improve limit enforcement and consistency.

* **Bug Fixes**
  * Returns a clear error when adding or removing members from a non-existent group.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->